### PR TITLE
Replace references to old repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <artifactoryBaseUrl>http://ch-jenkins-2k8.internal.ch:8081/artifactory</artifactoryBaseUrl>
+    <artifactoryBaseUrl>http://repository.aws.chdev.org:8081/artifactory</artifactoryBaseUrl>
     <publishRepo>dev</publishRepo>
   </properties>
 


### PR DESCRIPTION
Remove reference to old artifactory
in readiness of migration to Concourse: [CC-76](https://companieshouse.atlassian.net/browse/CC-76)

[CC-76]: https://companieshouse.atlassian.net/browse/CC-76?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ