### PR TITLE
remove target dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,3 @@
-SHELL := /bin/bash
-
-# link the required jar files to publish into a main ./target dir
-# as that is where Concourse maven task will look into:
-# https://github.com/companieshouse/ci-concourse-resources/blob/8bd37b/tasks/java-8/oracle-jdk/maven/build-package-library/task.yml#L26
-MAIN_TARGET_DIR := ./target
-
-# list the required modules to export
-MODULES_TO_PUBLISH := flying-saucer-pdf
-# at the time of writing only 1 module (flying-saucer-pdf) is used:
-# https://github.com/companieshouse/document-render-from-html5/blob/0379e05/pom.xml#L32
-# anyhow just list any other desired modules i.e. MODULES_TO_PUBLISH := flying-saucer-pdf  flying-saucer-swt flying-saucer-core
-
 .PHONY: all
 all: build
 
@@ -37,13 +24,6 @@ endif
 	$(info Packaging version: $(version))
 	mvn versions:set -DnewVersion=$(version) -DgenerateBackupPoms=false
 	mvn package -DskipTests=true
-	@echo  "creating sym.links in $(MAIN_TARGET_DIR) to jar files in [$(MODULES_TO_PUBLISH)]:"
-	$(shell mkdir -p $(MAIN_TARGET_DIR))
-	$(foreach MODULE,$(MODULES_TO_PUBLISH), \
-	   for jar in $(MODULE)/target/*.jar; do \
-	   ln -sf ../$$jar $(MAIN_TARGET_DIR)/`basename $$jar`; \
-	   done ; \
-	)
 
 .PHONY: dist
 dist: clean package


### PR DESCRIPTION
the multi-module logic is stripped off the Makefile
and it's going to be driven in Concourse via the resource: 
https://github.com/spring-io/artifactory-resource